### PR TITLE
DBのコネクションを使い回せるようにする

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,3 +2,7 @@
 lint:
 	@which golangci-lint >/dev/null || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v1.54.1
 	golangci-lint run ./...
+
+.PHONY: dev
+dev:
+	SADNESS_MYSQL_DATABASE=micro_post SADNESS_MYSQL_USER=ojisan SADNESS_MYSQL_PASSWORD=ojisan SADNESS_MYSQL_HOST=localhost:3306 go run main.go

--- a/router/home.go
+++ b/router/home.go
@@ -1,15 +1,13 @@
 package router
 
 import (
-	"database/sql"
 	"html/template"
 	"log"
 	"net/http"
-	"os"
 	"time"
 )
 
-func HomeHandler(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) HomeHandler(w http.ResponseWriter, r *http.Request) {
 	token, err := r.Cookie("token")
 	// cookie に token がないなら home ページを表示
 	if err != nil {
@@ -23,20 +21,7 @@ func HomeHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	dsn := os.Getenv("dbdsn")
-	db, err := sql.Open("mysql", dsn)
-	if err != nil {
-		log.Printf("ERROR: db open err: %v", err)
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-	defer func() {
-		if err := db.Close(); err != nil {
-			log.Printf("ERROR: db close err: %v", err)
-		}
-	}()
-
-	row := db.QueryRow("select user_id from session where token = ? limit 1", token.Value)
+	row := h.db.QueryRow("select user_id from session where token = ? limit 1", token.Value)
 	var userID int
 	if err := row.Scan(&userID); err != nil {
 		// token に紐づくユーザーがないので認証エラー。token リセットしてホームに戻す。

--- a/router/router.go
+++ b/router/router.go
@@ -1,0 +1,11 @@
+package router
+
+import "database/sql"
+
+type Handler struct {
+	db *sql.DB
+}
+
+func NewHandler(db *sql.DB) *Handler {
+	return &Handler{db: db}
+}

--- a/router/signout.go
+++ b/router/signout.go
@@ -1,28 +1,19 @@
 package router
 
 import (
-	"database/sql"
 	"log"
 	"net/http"
-	"os"
 	"time"
 )
 
 // どんな結果だろうと必ずクッキーを消すようにする。early return しない。
-func SignoutHandler(w http.ResponseWriter, r *http.Request) {
-	dsn := os.Getenv("dbdsn")
-	db, err := sql.Open("mysql", dsn)
-	if err != nil {
-		log.Printf("ERROR: db open err: %v", err)
-	}
-	defer db.Close()
-
+func (h *Handler) SignoutHandler(w http.ResponseWriter, r *http.Request) {
 	token, err := r.Cookie("token")
 	if err != nil {
 		log.Printf("ERROR: %v", err)
 	}
 
-	ins, err := db.Prepare("delete from session where token =?")
+	ins, err := h.db.Prepare("delete from session where token =?")
 	if err != nil {
 		log.Printf("ERROR: prepare token delete err: %v", err)
 	}


### PR DESCRIPTION
リクエストがあるたびに `sql.Open` して `sql.Close` するとコネクションが使い回せないので、main関数で `sql.Open` して得られる `sql.DB` を使い回すようにします。sql.DB自体にコネクションプールを管理する機能があるのでこれで問題なく動作します。